### PR TITLE
configure and validate Rtools path

### DIFF
--- a/files/MkRules.local.in
+++ b/files/MkRules.local.in
@@ -1,6 +1,6 @@
 #-*- Makefile -*-
 
-RTOOLS=C:/Rtools
+RTOOLS=@RTOOLS@
 
 ### For multilib compiler ###
 # TOOL_PATH = C:/Rtools/gcc-4.6.3/bin/

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,7 +1,14 @@
 ::set target=R-devel.tar.gz
 set TARBALL=%1
 if not exist "%TARBALL%" (
-echo File not found: %TARBALL% && exit /b 1
+	echo File not found: %TARBALL% && exit /b 1
+)
+
+:: Check for Rtools
+if not defined RTOOLS_BIN set RTOOLS_BIN=C:\Rtools\bin
+if not exist %RTOOLS_BIN% (
+	echo Rtools installation not found; expected at %RTOOLS_BIN%
+	exit /b 1
 )
 
 ::set WIN=32
@@ -28,7 +35,7 @@ set TMPDIR=%TEMP%
 set HOME32=%BUILDDIR%\%VERSION%-win32
 
 :: Add rtools executables in path
-set PATH=C:\rtools\bin;%PATH%
+set PATH=%RTOOLS_BIN%;%PATH%
 
 :: Copy sources
 rm -Rf %R_NAME%
@@ -58,7 +65,7 @@ sed -i "s/-lcairo -lpixman-1 -lpng -lz/-lcairo -lfontconfig -lfreetype -lpng -lp
 ::echo cat('R-experimental') > %R_HOME%/src/gnuwin32/fixed/rwver.R
 ::sed -i "s|Unsuffered Consequences|Blame Jeroen|" %R_HOME%/VERSION-NICK
 
-echo PATH="C:\Rtools\bin;${PATH}" > %R_HOME%/etc/Renviron.site
+echo PATH="%RTOOLS_BIN%;${PATH}" > %R_HOME%/etc/Renviron.site
 
 :: Switch dir
 cd %R_HOME%/src/gnuwin32

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -10,7 +10,10 @@ if not exist %RTOOLS_BIN% (
 	echo Rtools installation not found; expected at %RTOOLS_BIN%
 	exit /b 1
 )
+
+:: Generate path to Rtools root (using forward slashes)
 set RTOOLS=%RTOOLS_BIN:~0,-4%
+set RTOOLS=%RTOOLS:\=/%
 
 ::set WIN=32
 ::set WIN=64

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -22,9 +22,16 @@ set WIN=%2
 ::globals
 set STARTDIR=%CD%
 set SOURCEDIR=%~dp0..
-mkdir ..\BUILD
-cd ..\BUILD
-set BUILDDIR=%CD%
+
+:: build directory
+if not defined %BUILDDIR% (
+	mkdir ..\BUILD
+	cd ..\BUILD
+	set BUILDDIR=%CD%
+) else (
+	mkdir %BUILDDIR%
+	cd %BUILDDIR%
+)
 
 echo SOURCEDIR: %SOURCEDIR%
 echo BUILDDIR: %BUILDDIR%

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -10,6 +10,7 @@ if not exist %RTOOLS_BIN% (
 	echo Rtools installation not found; expected at %RTOOLS_BIN%
 	exit /b 1
 )
+set RTOOLS=%RTOOLS_BIN:~0,-4%
 
 ::set WIN=32
 ::set WIN=64
@@ -43,7 +44,7 @@ mkdir %R_NAME%
 tar -xf %SOURCEDIR%/%TARBALL% -C %R_NAME% --strip-components=1
 set XR_HOME=%R_HOME:\=/%
 set XHOME32=%HOME32:\=/%
-sed -e "s|@win@|%WIN%|" -e "s|@home@|%XR_HOME%|" -e "s|@home32@|%XHOME32%|" %SOURCEDIR%\files\MkRules.local.in > %R_HOME%/src/gnuwin32/MkRules.local
+sed -e "s|@win@|%WIN%|" -e "s|@home@|%XR_HOME%|" -e "s|@home32@|%XHOME32%|" -e "s|@RTOOLS@|%RTOOLS%|g" %SOURCEDIR%\files\MkRules.local.in > %R_HOME%/src/gnuwin32/MkRules.local
 
 :: Copy libraries
 cp -R %SOURCEDIR%\libcurl %R_HOME%\libcurl


### PR DESCRIPTION
This allows users to set RTOOLS_BIN to point to an alternative Rtools location (e.g. if someone has multiple copies of Rtools installed)